### PR TITLE
chore: ignore ruff CPY001 copyright rule

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -14,6 +14,7 @@ ignore = [
     "COM812", # incompatible with formatter
     "ISC001", # incompatible with formatter
     "EXE002",
+    "CPY001", # per-file copyright headers, licensing lives in LICENSE
 ]
 
 [lint.flake8-pytest-style]


### PR DESCRIPTION
Ruff 0.16 promoted `flake8-copyright` out of preview, so this repo's `select = ["ALL"]` now flags all 16 Python files with `CPY001 Missing copyright notice at top of file`.

Licensing lives in `LICENSE`, and Home Assistant core (which `.ruff.toml` is based on) doesn't use per-file copyright headers, so ignore the rule rather than adding headers everywhere.

Unblocks the `ruff==0.16.3` bump in #54.